### PR TITLE
fix: removed opacity on activeIndex for screens <640px wide

### DIFF
--- a/app/components/search/QueryResults.tsx
+++ b/app/components/search/QueryResults.tsx
@@ -77,7 +77,7 @@ function QueryResults<T>({
             <div
               className={classNames(
                 "hover:opacity-50",
-                index === activeIndex && "opacity-75",
+                index === activeIndex && "sm:opacity-75",
               )}
             >
               {renderResult(datum)}


### PR DESCRIPTION
On screens <640px wide, the opacity 75 no longer applies to the activeIndex. this is so that mobile users using the web version do not have to constantly see the first element highlighted (which looks bad and is unintuitive)

<img width="1458" height="471" alt="image" src="https://github.com/user-attachments/assets/17a7f41e-7706-45ef-b62d-3e1aa17bf3d9" />
<img width="604" height="499" alt="image" src="https://github.com/user-attachments/assets/46d53787-2dff-4c19-99ac-12a4f4118868" />

the first screenshot is regular, and the second is when the width is <640px